### PR TITLE
Makefile: `clean` target uses rm -f

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ test: natsort
 	@bash ./run-tests.bash
 
 clean:
-	rm natsort $(OBJS)
+	rm -f natsort $(OBJS)

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,16 @@ CFLAGS = -Wall -g -Werror
 
 OBJS = strnatcmp.o natsort.o
 
-.PHONY: clean test
+.PHONY: analyze clean test
 
 natsort: $(OBJS)
 	$(CC) -o $@ $(OBJS)
 
 test: natsort
 	@bash ./run-tests.bash
+
+analyze: clean
+	scan-build --status-bugs make
 
 clean:
 	rm -f natsort $(OBJS)


### PR DESCRIPTION
Running `make clean` on a clean directory would cause `rm` to warn about missing files. Use the -f flag to suppress the warnings.
