### PR TITLE
Fix the incorrect word example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ are compared on their numeric value.  For example,
 
 Strings can contain several number parts:
 
-    x2-g8 < x2-y7 < x2-y08 < x8-y8
+    x2-g8 < x2-y08 < x2-y7 < x8-y8
 
 in which case numeric fields are separated by nonnumeric characters.
 Leading spaces are ignored.  This works very well for IP addresses


### PR DESCRIPTION
According to the file `sorted-words`, the example should be `x2-g8 < x2-y08 < x2-y7 < x8-y8` rather than `x2-g8 < x2-y7 < x2-y08 < x8-y8`.

Moreover, `x2-g8 < x2-y7 < x2-y08 < x8-y8` contradicts with `1.001 < 1.002 < 1.010 < 1.02 < 1.1 < 1.3`, and this is why:
`x2-y7 < x2-y08`
`1.02 < 1.1`

Remove the common terms:
`7 < 08`
`02 < 1`

Substitute the digits while preserving the ordering:
`1 < 02`
`02 < 1`

Transpose the terms:
`02 > 1`
`02 < 1`

So this is a contradiction.

This pull request fixes the documentation issue.