### PR TITLE
CI: replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,18 @@ name: Build
 on: [push]
 
 jobs:
+  Analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install clang-tools
+      - name: Analyze
+        run: make analyze
+
   Build:
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: Build
+
+on: [push]
+
+jobs:
+  Build:
+    strategy:
+      matrix:
+        cc: [gcc, clang]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Compile
+        env:
+          CC: ${{matrix.cc}}
+        run: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: c
-compiler:
-  - clang
-  - gcc
-script:
-  - make test
-sudo: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Natural Order String Comparison
 
+[![Build](https://github.com/sourcefrog/natsort/actions/workflows/ci.yml/badge.svg)](https://github.com/sourcefrog/natsort/actions/workflows/ci.yml)
+
 Martin Pool <http://sourcefrog.net>
 
 Computer string sorting algorithms generally don't order strings


### PR DESCRIPTION
Note that the Analyze step (running Clang's static analyzer, `scan-build`, on the code) does not pass cleanly yet.

Closes #8.