### PR TITLE
Added extern "C" around strnatcmp.h

### DIFF
--- a/strnatcmp.h
+++ b/strnatcmp.h
@@ -20,6 +20,9 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /* CUSTOMIZATION SECTION
  *
@@ -29,3 +32,7 @@ typedef char nat_char;
 
 int strnatcmp(nat_char const *a, nat_char const *b);
 int strnatcasecmp(nat_char const *a, nat_char const *b);
+  
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Per the instruction [here](https://isocpp.org/wiki/faq/mixing-c-and-cpp#include-c-hdrs-personal), I added `extern "C"` guards around the `strnatcmp.h` header. This makes it easier to include natsort in a C++ project. 

This should have no affect in a pure C project:
> the symbol __cplusplus is #defined if/only-if the compiler is a C++ compiler [[source](https://isocpp.org/wiki/faq/mixing-c-and-cpp#include-c-hdrs-personal)]